### PR TITLE
FrontendController logging, routePattern and WebSocket trailing slash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @asenajs/hono-adapter
 
+## 1.5.1
+
+### Patch Changes
+
+- ### Features
+  - **FrontendController Logging**: FrontendController routes are now logged in the controller summary with route counts, grouped by controller name and base path.
+  - **Route Pattern**: Added `routePattern` getter to `HonoContextWrapper` that returns Hono's `req.routePath`, enabling OpenTelemetry and middleware to access matched route patterns.
+
+  ### Fixes
+  - **WebSocket Trailing Slash**: Fixed WebSocket connection failures caused by trailing slashes in namespace paths. Both `HonoAdapter` and `HonoWebsocketAdapter` now normalize paths by stripping trailing slashes.
+  - **Server Stop**: `stop()` method now properly awaits server shutdown.
+
+  ### Tests
+  - Added FrontendController summary logging tests.
+  - Added WebSocket trailing slash normalization test.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
   },
   "packages": {
-    "@asenajs/asena": ["@asenajs/asena@0.7.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-qU+NkkorV8rx++AT1snv5WG7+BVaiwzM8541pbENRwYx1nxqp8BgYEv01LHkJFNR28VrEqAo1lhvOuEhNe4oYQ=="],
+    "@asenajs/asena": ["@asenajs/asena@0.7.1", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-bSk+6iDZSup4PctgsaeS9YJuRG7C7sbt/xkqtt1gpAozcfWmRSOTzhS0WV95hNen11xowxA064FeO9QwzZWMVA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -105,33 +105,33 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/type-utils": "8.58.0", "@typescript-eslint/utils": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/type-utils": "8.58.1", "@typescript-eslint/utils": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.0", "@typescript-eslint/types": "^8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.1", "@typescript-eslint/types": "^8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0" } }, "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1" } }, "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.1", "", {}, "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.0", "@typescript-eslint/tsconfig-utils": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.1", "@typescript-eslint/tsconfig-utils": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -153,11 +153,11 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -241,7 +241,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.11", "", {}, "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA=="],
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
@@ -329,7 +329,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+    "prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -373,7 +373,7 @@
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -383,9 +383,9 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.58.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.0", "@typescript-eslint/parser": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA=="],
+    "typescript-eslint": ["typescript-eslint@8.58.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.1", "@typescript-eslint/parser": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 

--- a/lib/HonoAdapter.ts
+++ b/lib/HonoAdapter.ts
@@ -33,7 +33,7 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
 
   public app: Hono;
 
-  private _strict: boolean = true;
+  private readonly _strict: boolean = true;
 
   private server: Server<WebSocketData>;
 
@@ -55,7 +55,7 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
 
   public async stop(closeActiveConnections = true): Promise<void> {
     if (this.server) {
-      this.server.stop(closeActiveConnections);
+      await this.server.stop(closeActiveConnections);
     }
   }
 
@@ -82,6 +82,11 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
    * Stored separately and merged into Bun.serve() routes at start time
    */
   private htmlRoutes = new Map<string, unknown>();
+
+  /**
+   * Queue of FrontendController route metadata for deferred logging at start time
+   */
+  private frontEndRouteQueue: { path: string; controllerName: string; controllerBasePath: string }[] = [];
 
   private routesRegistered = false;
 
@@ -174,12 +179,18 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
    * @param path - Full URL path (e.g., '/ui/home')
    * @param htmlBundle - The HTML bundle returned by importing an .html file
    */
-  public registerHTMLRoute(path: string, htmlBundle: unknown): void {
+  public registerHTMLRoute(
+    path: string,
+    htmlBundle: unknown,
+    controllerName: string,
+    controllerBasePath: string,
+  ): void {
     if (this.htmlRoutes.has(path)) {
       throw new Error(`Duplicate HTML route: "${path}" is already registered.`);
     }
 
     this.htmlRoutes.set(path, htmlBundle);
+    this.frontEndRouteQueue.push({ path, controllerName, controllerBasePath });
 
     // Register trailing slash variant for consistent routing
     if (path !== '/' && !path.endsWith('/')) {
@@ -249,7 +260,7 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
     this.websocketAdapter.startWebsocket(this.server);
 
     // Log controller-based route information
-    if (this.routeQueue.length > 0 || this.wsRouteQueue.length > 0) {
+    if (this.routeQueue.length > 0 || this.wsRouteQueue.length > 0 || this.frontEndRouteQueue.length > 0) {
       this.logger.info('\n' + this.buildControllerBasedLog());
     }
 
@@ -742,6 +753,18 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
         );
       }
     }
+
+    // Log FrontendControllers
+    const frontEndGroups = this.groupFrontEndRoutesByController();
+
+    for (const [controllerName, group] of frontEndGroups) {
+      const routeCount = group.routes.length;
+      const routeText = routeCount === 1 ? 'route' : 'routes';
+
+      this.logger.info(
+        `${green('✓')} Successfully registered ${yellow('FRONTEND')} ${blue(controllerName)} ${yellow(`(${routeCount} ${routeText})`)}`,
+      );
+    }
   }
 
   /**
@@ -758,12 +781,15 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
     // Combine: global middlewares -> route middlewares
     const allMiddlewares = [...preparedGlobalMiddlewares, ...preparedMiddlewares];
 
-    (this.app as any).get(`/${wsRoute.path}`, ...allMiddlewares, async (c: Context, next) => {
+    const normalizedWsPath = this.normalizePath(`/${wsRoute.path}`);
+
+    (this.app as any).get(normalizedWsPath, ...allMiddlewares, async (c: Context, next) => {
       const websocketData = c.get('_websocketData') || {};
 
       const id = bun.randomUUIDv7();
 
-      const data: WebSocketData = { values: websocketData, id, path: wsRoute.path };
+      const dataPath = normalizedWsPath.startsWith('/') ? normalizedWsPath.slice(1) : normalizedWsPath;
+      const data: WebSocketData = { values: websocketData, id, path: dataPath };
       const upgradeResult = this.server.upgrade(c.req.raw, { data });
 
       if (upgradeResult) {
@@ -1059,6 +1085,40 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
       lines.push(''); // Empty line between controllers
     }
 
+    // Add FrontendController groups
+    const frontEndGroups = this.groupFrontEndRoutesByController();
+    const sortedFrontEnd = Array.from(frontEndGroups.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+    for (const [controllerName, group] of sortedFrontEnd) {
+      lines.push(`  ${blue(controllerName)} ${yellow(`(${group.basePath})`)}`);
+
+      for (const route of group.routes) {
+        lines.push(`    ${green('HTML')} ${route.path}`);
+      }
+
+      lines.push('');
+    }
+
     return lines.join('\n');
+  }
+
+  /**
+   * Groups FrontendController routes by controller name for logging
+   */
+  private groupFrontEndRoutesByController(): Map<string, { basePath: string; routes: { path: string }[] }> {
+    const groups = new Map<string, { basePath: string; routes: { path: string }[] }>();
+
+    for (const route of this.frontEndRouteQueue) {
+      if (!groups.has(route.controllerName)) {
+        groups.set(route.controllerName, {
+          basePath: route.controllerBasePath,
+          routes: [],
+        });
+      }
+
+      groups.get(route.controllerName).routes.push({ path: route.path });
+    }
+
+    return groups;
   }
 }

--- a/lib/HonoContextWrapper.ts
+++ b/lib/HonoContextWrapper.ts
@@ -28,6 +28,14 @@ export class HonoContextWrapper implements AsenaContext<HonoRequest<any, any>, R
     return this._context.res;
   }
 
+  public get routePattern(): string | undefined {
+    try {
+      return this._context.req.routePath;
+    } catch {
+      return undefined;
+    }
+  }
+
   public get headers(): Record<string, string> {
     return this._context.req.header();
   }

--- a/lib/HonoWebsocketAdapter.ts
+++ b/lib/HonoWebsocketAdapter.ts
@@ -66,11 +66,16 @@ export class HonoWebsocketAdapter extends AsenaWebsocketAdapter {
       throw new Error('WebSocket service is required');
     }
 
-    const namespace = webSocketService.namespace;
+    const rawNamespace = webSocketService.namespace;
 
-    if (!namespace) {
+    if (!rawNamespace) {
       throw new Error('WebSocket namespace is required');
     }
+
+    // Normalize namespace: strip trailing slash for consistent lookup
+    const namespace = rawNamespace.length > 1 && rawNamespace.endsWith('/')
+      ? rawNamespace.slice(0, -1)
+      : rawNamespace;
 
     // Validate namespace format (alphanumeric, hyphens, underscores, slashes)
     if (!/^[a-zA-Z0-9\-_/]+$/.exec(namespace)) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "README.md",
     "LICENSE"
   ],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "LibirSoft",
   "repository": {
     "type": "git",

--- a/test/HonoAdapter.test.ts
+++ b/test/HonoAdapter.test.ts
@@ -1363,20 +1363,56 @@ describe('HonoAdapter', () => {
     it('should register HTML route and its trailing slash variant', () => {
       const { adapter } = createTestAdapter();
 
-      adapter.registerHTMLRoute('/ui/home', '<html>Home</html>');
+      adapter.registerHTMLRoute('/ui/home', '<html>Home</html>', 'FrontEnd', '/ui');
 
       // Should not throw for a different path
-      adapter.registerHTMLRoute('/ui/about', '<html>About</html>');
+      adapter.registerHTMLRoute('/ui/about', '<html>About</html>', 'FrontEnd', '/ui');
     });
 
     it('should throw on duplicate HTML route', () => {
       const { adapter } = createTestAdapter();
 
-      adapter.registerHTMLRoute('/ui/home', '<html>Home</html>');
+      adapter.registerHTMLRoute('/ui/home', '<html>Home</html>', 'FrontEnd', '/ui');
 
       expect(() => {
-        adapter.registerHTMLRoute('/ui/home', '<html>Duplicate</html>');
+        adapter.registerHTMLRoute('/ui/home', '<html>Duplicate</html>', 'FrontEnd', '/ui');
       }).toThrow('Duplicate HTML route');
+    });
+
+    it('should log FRONTEND controller summary on start', async () => {
+      const { adapter, logger } = createTestAdapter();
+      const mockBundle = new Response('<html>Home</html>', { headers: { 'Content-Type': 'text/html' } });
+      const mockBundle2 = new Response('<html>About</html>', { headers: { 'Content-Type': 'text/html' } });
+
+      adapter.registerHTMLRoute('/ui/home', mockBundle, 'FrontEnd', '/ui');
+      adapter.registerHTMLRoute('/ui/about', mockBundle2, 'FrontEnd', '/ui');
+
+      server = (await adapter.start()) as any;
+
+      const infoCalls = (logger.info as any).mock.calls.map((c: any) => c[0]);
+      const summaryLog = infoCalls.find((msg: string) => msg.includes('FRONTEND') && msg.includes('FrontEnd'));
+      const detailLog = infoCalls.find((msg: string) => msg.includes('HTML') && msg.includes('/ui/home'));
+
+      expect(summaryLog).toBeDefined();
+      expect(detailLog).toBeDefined();
+    });
+
+    it('should group frontend routes by controller in log output', async () => {
+      const { adapter, logger } = createTestAdapter();
+      const mockBundle1 = new Response('<html>Home</html>', { headers: { 'Content-Type': 'text/html' } });
+      const mockBundle2 = new Response('<html>Dashboard</html>', { headers: { 'Content-Type': 'text/html' } });
+
+      adapter.registerHTMLRoute('/ui/home', mockBundle1, 'FrontEnd', '/ui');
+      adapter.registerHTMLRoute('/admin/dashboard', mockBundle2, 'AdminFrontEnd', '/admin');
+
+      server = (await adapter.start()) as any;
+
+      const infoCalls = (logger.info as any).mock.calls.map((c: any) => c[0]);
+      const hasFrontEnd = infoCalls.some((msg: string) => msg.includes('FrontEnd'));
+      const hasAdmin = infoCalls.some((msg: string) => msg.includes('AdminFrontEnd'));
+
+      expect(hasFrontEnd).toBe(true);
+      expect(hasAdmin).toBe(true);
     });
   });
 
@@ -1537,6 +1573,65 @@ describe('HonoAdapter', () => {
       // Test by verifying the health route still works
       const healthRes = await fetch(`${baseUrl}/health`);
       expect(healthRes.status).toBe(200);
+    });
+
+    it('should normalize websocket path by stripping trailing slash', async () => {
+      const { adapter } = createTestAdapter();
+
+      const onMessageMock = mock(async () => {});
+
+      const wsService = {
+        namespace: 'ws/stats/',
+        sockets: new Map(),
+        onOpenInternal: mock(async () => {}),
+        onMessage: mock(async (ws: any, message: any) => {
+          ws.send(typeof message === 'string' ? message : message.toString());
+          await onMessageMock();
+        }),
+        onCloseInternal: mock(async () => {}),
+      };
+
+      adapter.registerWebsocketRoute({
+        path: 'ws/stats/',
+        middlewares: [],
+        websocketService: wsService as any,
+        controllerName: 'StatsController',
+      });
+
+      await registerRoute(adapter, {
+        path: '/health',
+        handler: (ctx) => ctx.send({ ok: true }),
+      });
+
+      const { server: s } = await startTestServer(adapter);
+      server = s;
+
+      // Connect WITHOUT trailing slash — should work after normalization
+      const ws = new WebSocket(`ws://localhost:${server.port}/ws/stats`);
+
+      const messagePromise = new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('WS message timeout')), 3000);
+
+        ws.onmessage = (e) => {
+          clearTimeout(timeout);
+          resolve(typeof e.data === 'string' ? e.data : '');
+        };
+
+        ws.onerror = () => {
+          clearTimeout(timeout);
+          reject(new Error('WebSocket error'));
+        };
+      });
+
+      await new Promise<void>((resolve) => {
+        ws.onopen = () => resolve();
+      });
+
+      ws.send('ping');
+      const response = await messagePromise;
+      expect(response).toBe('ping');
+
+      ws.close();
     });
   });
 


### PR DESCRIPTION
- FrontendController routes are now logged in the controller summary, grouped by controller.
- Added `routePattern` getter to `HonoContextWrapper`. Returns Hono's `req.routePath`, providing route pattern access for OTel and middleware.
- **Bug Fix:** Fixed trailing slash issue in WebSocket namespace paths. Both `HonoAdapter` and `HonoWebsocketAdapter` now normalize paths, preventing connection failures caused by trailing slashes.
- `stop()` method now properly awaits server shutdown.