### PR TITLE
Release-v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,91 @@
 # @asenajs/hono-adapter
 
+## 3.0.0
+
+### Major Changes
+
+- `hono` and `zod` are now peer dependencies
+
+  The adapter's job is to offer a wrapper, not to supply the framework it wraps. Both libraries are
+  part of the contract between this package and your application - `HTTPException` and `Context` come
+  from hono, `ValidationService.json()` returns a zod schema, and all of them appear in the published
+  `.d.ts` - so both must be the _same copy_ your application resolves. Declaring them as
+  `dependencies` gave this package its own resolution slot, and that slot is a bug waiting for a
+  lockfile to fill it.
+
+  It did. A downstream application bumped `hono: ^4.12.9 -> ^4.12.32`, bun kept the adapter's
+  already-satisfied copy nested under `@asenajs/hono-adapter/node_modules/hono`, and every deliberate
+  400/403 thrown from `hono/http-exception` silently became a 500 while the API kept answering. 46/46
+  of that app's tests stayed green. `brandHonoHttpException()` patches the prototype of the copy _this
+  package_ resolved; a prototype patch cannot reach another copy's class. The split was not even
+  semver-forced - `4.12.32` satisfied `^4.12.9` too. Only the extra resolution slot made it possible.
+
+  ## Migration
+
+  ```bash
+  bun add hono zod
+  rm -rf node_modules bun.lock && bun install
+  ```
+
+  The `rm -rf` is not optional when upgrading in place. A previous `bun install` has been observed to
+  drop the nested copy from the lockfile while **leaving the directory on disk**, and two directories
+  are two classes regardless of whether the versions match.
+
+  | Package manager      | What you need to do                                                                                   |
+  | :------------------- | :---------------------------------------------------------------------------------------------------- |
+  | bun, npm 7+, pnpm 8+ | Peers auto-install, but declare them anyway - an undeclared peer disappears on the next clean install |
+  | yarn 1               | **Required.** yarn 1 does not install peers, so without this the server fails at boot                 |
+
+  ## Details
+  - Requires **hono >= 4.12.9** and **zod ^4.3.6**. `flattenError` is a zod-v4 top-level export and is
+    called at runtime, so zod 3 will not work.
+  - `hono` is declared as a floor (`>=4.12.9`) rather than a caret, deliberately: a peer range that
+    cannot be satisfied is the one remaining way to make npm or pnpm nest a second copy. A hono major
+    mismatch instead shows up as a type error in your build, because this package's `.d.ts` references
+    hono's types directly - which is loud, where a duplicate copy is silent.
+  - `@hono/zod-validator` remains a regular dependency. You never import it, it declares no
+    dependencies of its own, and its own hono/zod peers resolve to yours.
+  - The adapter now writes a startup warning if it finds itself resolving a `hono` nested under
+    `@asenajs/hono-adapter/node_modules/hono` - the one duplicate topology it can detect from the
+    inside, and the one a stale directory leaves behind.
+  - Nothing in the API changed.
+
+### Minor Changes
+
+- Answer `HttpException` from core, and derive the log level from the status the caller received
+
+  Applications can now throw `HttpException` from `@asenajs/asena/adapter` - the same class, and the
+  same throw, that works on `@asenajs/ergenecore`. Requires `@asenajs/asena` `>=0.9.2`; the peer
+  range moves to `^0.9.2`.
+
+  This package does **not** re-export it. It already exports hono's `HTTPException`, and two
+  throwable, branded classes whose names differ by the case of two letters is a trap for
+  autocomplete - only one of them is the portable one. Import `HttpException` from
+  `@asenajs/asena/adapter` and `HTTPException` from here.
+
+  **Hono's `HTTPException` is unaffected.** It is still exported, still branded, and still answered
+  first - by `instanceof`, deliberately, so that it does not depend on the prototype patch having
+  run. Everything `hono/basic-auth`, `hono/bearer-auth`, `hono/jwt` and hono's own validator throw
+  keeps working exactly as before, and there are now end-to-end tests pinning that.
+
+  Two fixes come with it:
+
+  - **A branded exception from a second resolved copy answered 500.** `defaultErrorResponse` chose
+    the response with `error instanceof HTTPException`, so anything branded but not an instance of
+    _this_ copy of hono's class fell through to the generic 500 - which is precisely the failure the
+    `HTTP_EXCEPTION` brand was introduced to prevent. It now checks the brand, and honours the
+    status even when the exception carries no `getResponse()`. The body is withheld in that case:
+    an exception the adapter does not recognise is not known to carry a message that is safe to
+    send to the caller.
+
+  - **The response and the log could disagree about the same request.** `logHandledError` derived
+    its level by duck-typing a numeric `.status` off the error, independently of how the response
+    was chosen. A plain `Error` carrying a stray `.status = 401` was answered 500 and logged at
+    debug as a 4xx; a branded foreign exception was answered 500 and logged as whatever status it
+    carried. Both now go through one `resolveErrorStatus`, so the logged status always equals the
+    answered status - asserted as an invariant rather than a list of expected values, so the two
+    cannot drift again.
+
 ## 2.0.0
 
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Asena Hono Adapter
 
-[![Version](https://img.shields.io/badge/version-2.0.0-blue.svg)](https://github.com/AsenaJs/hono-adapter)
+[![Version](https://img.shields.io/badge/version-3.0.0-blue.svg)](https://github.com/AsenaJs/hono-adapter)
 [![Bun Version](https://img.shields.io/badge/Bun-1.3.12%2B-blueviolet)](https://bun.sh)
 
 HTTP and WebSocket adapter implementation based on Hono web framework for Asena.js.
@@ -18,14 +18,27 @@ HTTP and WebSocket adapter implementation based on Hono web framework for Asena.
 ## Requirements
 
 - [Bun](https://bun.sh) v1.3.12 or higher
+- [@asenajs/asena](https://github.com/AsenaJs/Asena) v0.10.0 or higher (peer dependency)
+- [Hono](https://hono.dev) v4.12.9 or higher (peer dependency)
+- [Zod](https://zod.dev) v4.3.6 or higher (peer dependency)
 - TypeScript v5.8.2 or above
 
 ## Installation
 
-1. Install with NPM package manager:
 ```bash
-bun add @asenajs/hono-adapter
+bun add @asenajs/hono-adapter hono zod
 ```
+
+`hono` and `zod` are **peer dependencies** - this adapter offers the wrapper, your project owns the
+libraries it wraps. That is what keeps your code and the adapter on a single copy of `hono`; two
+copies mean two `HTTPException` classes, and a deliberate 403 thrown from the wrong one is answered
+500.
+
+| Package manager | Command |
+|:--|:--|
+| bun, npm 7+, pnpm 8+ | `bun add hono zod` — peers auto-install, but declare them anyway so they survive a clean install |
+| yarn 1 | `yarn add hono zod` — **required**, yarn 1 does not install peers for you |
+
 
 ## Usage
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,28 +6,31 @@
       "name": "@asenajs/hono-adapter",
       "dependencies": {
         "@hono/zod-validator": "^0.9.0",
-        "hono": "^4.12.9",
-        "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@asenajs/asena": "^0.9.0",
+        "@asenajs/asena": "^0.10.0",
         "@changesets/cli": "^2.30.0",
         "@types/bun": "latest",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^9.1.2",
+        "hono": "^4.12.32",
         "prettier": "^3.8.1",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.0",
+        "zod": "^4.3.6",
       },
       "peerDependencies": {
-        "@asenajs/asena": "^0.9.0",
+        "@asenajs/asena": "^0.10.0",
+        "hono": ">=4.12.9",
         "typescript": "^5.8.2",
+        "zod": "^4.3.6",
       },
     },
   },
   "packages": {
-    "@asenajs/asena": ["@asenajs/asena@0.9.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-HmppB0r/32K6RfVSk9kHzS1dVxco1GbF9a+O1aYEBzDr5YRFET/c6HGne6kpOfZyu8vzGbwtRr8x/u4HkK4aOw=="],
+    "@asenajs/asena": ["@asenajs/asena@0.10.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-9UIjCWQARpWV5UWthaMPBVstN2/VTysGLSGV44MO8qeN6PSPhIa92jNgbMeVru1/d0MtJWiPjZnYV2g2ky8OeQ=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -113,7 +116,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.65.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/type-utils": "8.65.0", "@typescript-eslint/utils": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.65.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA=="],
 
@@ -135,7 +138,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
 
-    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
@@ -419,7 +422,7 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 

--- a/index.ts
+++ b/index.ts
@@ -5,5 +5,19 @@ export * from './lib/defaults';
 export * from './lib/utils/createHonoAdapter';
 export * from './lib/errors';
 
-// Re-export Hono's HTTPException for user convenience in middlewares
+/**
+ * Hono's own `HTTPException`, re-exported so applications and middlewares stay on the copy of
+ * `hono` this adapter resolved - importing it from `hono/http-exception` directly is what lets a
+ * project end up with two `HTTPException` classes that `instanceof` disagrees about.
+ *
+ * This is *not* the class to throw for an ordinary HTTP error. That is `HttpException` from
+ * `@asenajs/asena/adapter`, which is the same class on every adapter, so the same `throw`
+ * compiles and behaves identically on ergenecore and here. It is deliberately not re-exported
+ * from this package: two throwable, branded classes whose names differ by the case of two letters
+ * is a trap for autocomplete, and only one of them is the portable one.
+ *
+ * Both are recognised by `isHttpException()` and both are answered from their own status, so
+ * anything hono's ecosystem raises - `hono/basic-auth`, `hono/bearer-auth`, `hono/jwt`, hono's
+ * validator - keeps working exactly as before.
+ */
 export { HTTPException } from 'hono/http-exception';

--- a/lib/HonoAdapter.ts
+++ b/lib/HonoAdapter.ts
@@ -10,6 +10,7 @@ import {
   type AsenaStartOptions,
   type BaseMiddleware,
   type BaseValidator,
+  isHttpException,
   type RouteParams,
   VALIDATOR_METHODS,
   type ValidatorHandler,
@@ -27,7 +28,7 @@ import { blue, green, red, type ServerLogger, yellow } from '@asenajs/asena/logg
 import { type Hook, zValidator } from '@hono/zod-validator';
 import type { ValidationSchema, ValidationSchemaWithHook } from './defaults';
 import type { ZodError, ZodType } from 'zod';
-import { brandHonoHttpException, ValidationError } from './errors';
+import { brandHonoHttpException, ValidationError, warnOnNestedHono } from './errors';
 import { middlewareParser } from './utils/middlewareParser';
 import { compareRoutePriority } from './utils/routePriority';
 import type { Context as HonoAdapterContext } from './defaults/Context';
@@ -73,9 +74,39 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
     return path;
   }
 
+  /**
+   * Stops the HTTP surface and releases everything the adapter owns.
+   *
+   * The socket goes down first and the WebSocket adapter is torn down after it, for the same
+   * reason the core stops the adapter before running `@OnStop`: a transport has to outlive the
+   * things that publish through it. Destroying it while a message handler is still running would
+   * only turn a shutdown into an error in the log.
+   *
+   * `finally`, so the two failure directions are both covered - a `server.stop()` that rejects
+   * still releases the WebSocket resources, and a WebSocket teardown that fails cannot leave the
+   * port bound. A port that survives `stop()` is how a test suite starts failing with
+   * EADDRINUSE and how a rolling deploy keeps taking traffic it can no longer serve.
+   *
+   * @param closeActiveConnections - Whether to drop in-flight connections instead of draining them
+   */
   public async stop(closeActiveConnections = true): Promise<void> {
-    if (this.server) {
-      await this.server.stop(closeActiveConnections);
+    try {
+      if (this.server) {
+        await this.server.stop(closeActiveConnections);
+      }
+    } finally {
+      // Cast because `AsenaWebsocketAdapter` does not declare `shutdown()` - the constructor only
+      // ever accepts a HonoWebsocketAdapter, so the narrowing is the one the public API already
+      // guarantees.
+      const websocketAdapter = this.websocketAdapter as HonoWebsocketAdapter | undefined;
+
+      // Guarded rather than awaited bare: shutdown() already contains its own failures, but a
+      // throw from here would replace whatever `server.stop()` was reporting.
+      try {
+        await websocketAdapter?.shutdown();
+      } catch (error) {
+        this.logger.error('WebSocket shutdown failed during adapter stop:', error);
+      }
     }
   }
 
@@ -168,6 +199,10 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
     // Teach isHttpException() about Hono's own exception class. Doing it here rather than at
     // module scope keeps the side effect tied to actually using the adapter.
     brandHonoHttpException();
+
+    // ...and say so if that branding cannot possibly be enough, because `hono` resolved to a copy
+    // nested under this package rather than to the application's own.
+    warnOnNestedHono(this.logger);
   }
 
   /**
@@ -461,8 +496,30 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
   private defaultErrorResponse(error: Error, path: string, method: string): Response {
     this.logHandledError(error, path, method);
 
+    // Hono's own class first, and deliberately by `instanceof` rather than by the brand. The brand
+    // reaches it only because `brandHonoHttpException()` patched the prototype from this class's
+    // constructor; if that call is ever removed, reordered, or defeated by `hono/http-exception`
+    // resolving to a second copy inside a middleware, every 401 from `hono/basic-auth`,
+    // `hono/bearer-auth`, `hono/jwt` and hono's own validator would silently answer 500. This arm
+    // costs one check and cannot be defeated that way.
     if (error instanceof HTTPException) {
       return error.getResponse();
+    }
+
+    if (isHttpException(error)) {
+      // The class from `@asenajs/asena/adapter` - the one applications throw on both adapters -
+      // and any foreign copy that still carries a way to build its own response.
+      if (typeof error.getResponse === 'function') {
+        return error.getResponse();
+      }
+
+      // Branded, but with nothing to build a response from. Only `status` is in the contract, so
+      // honour that and withhold the body: an exception this adapter does not recognise is not
+      // known to carry a message that is safe to send to the caller.
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: error.status,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
@@ -472,13 +529,30 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
   }
 
   /**
+   * The status the caller will be answered with, for anything thrown.
+   *
+   * Shared by `defaultErrorResponse` and `logHandledError` so the response and the log line cannot
+   * disagree. They used to: the response was chosen by `instanceof HTTPException` while the log
+   * level was chosen by duck-typing a numeric `status` off the error. A plain `Error` carrying a
+   * stray `.status = 401` was therefore answered 500 and logged at debug as a 4xx, and a branded
+   * exception from a second copy was answered 500 and logged as whatever status it carried.
+   */
+  private resolveErrorStatus(error: unknown): number {
+    if (error instanceof HTTPException) return error.status;
+
+    if (isHttpException(error)) return error.status;
+
+    return 500;
+  }
+
+  /**
    * Logs an error that is about to be handed to the application's error handler.
    *
-   * The level is derived from the status the client will actually see: a 4xx is the
-   * caller's mistake and the auth/validation layer doing its job, so it must not flood the
-   * ERROR stream with stack traces - an unauthenticated request would otherwise be an
-   * attacker-controlled log amplifier. Only 5xx carries a stack, because that is the class
-   * of failure nobody predicted.
+   * The level is derived from the status the client will actually see - via the same
+   * `resolveErrorStatus` the response uses, so the two cannot drift. A 4xx is the caller's
+   * mistake and the auth/validation layer doing its job, so it must not flood the ERROR stream
+   * with stack traces - an unauthenticated request would otherwise be an attacker-controlled log
+   * amplifier. Only 5xx carries a stack, because that is the class of failure nobody predicted.
    *
    * `ServerLogger.debug` is optional, so fall back to `info` when an implementation does
    * not provide it.
@@ -486,7 +560,7 @@ export class HonoAdapter extends AsenaAdapter<HonoAdapterContext, ValidationSche
   private logHandledError(error: Error, path: string, method: string): void {
     if (this.logErrors === false) return;
 
-    const status = typeof (error as { status?: unknown }).status === 'number' ? (error as any).status : 500;
+    const status = this.resolveErrorStatus(error);
     const isServerError = status >= 500;
 
     const meta = {

--- a/lib/HonoWebsocketAdapter.ts
+++ b/lib/HonoWebsocketAdapter.ts
@@ -46,10 +46,27 @@ export class HonoWebsocketAdapter extends AsenaWebsocketAdapter {
   }
 
   /**
-   * Graceful shutdown - closes all connections
-   * @param _timeoutMs - Timeout for graceful shutdown (default: 5000)
+   * Releases everything this adapter owns: heartbeat timers, connection tracking, and the
+   * transport.
+   *
+   * The transport is the part that matters beyond a single process. `BunLocalTransport` has
+   * nothing to let go of, but a remote one holds broker state - `RedisTransport` keeps a
+   * subscriber connection with a live channel subscription plus a publisher - and `destroy()`
+   * had no call site anywhere in the framework, so every stop leaked both. A test suite doing
+   * twenty stop/start cycles, or a pod restarting under a rolling deploy, accumulates them until
+   * the broker refuses new clients.
+   *
+   * This method does **not** close sockets, despite the name it has carried since the first
+   * version. Closing them is `server.stop(closeActiveConnections)`'s job, and `HonoAdapter.stop()`
+   * has already done it by the time this runs; a second pass from here would only race with Bun.
+   * Called standalone, it leaves open connections alone - it just stops pinging them.
+   *
+   * @param timeoutMs - Ceiling for the transport teardown (default: 5000). A remote transport's
+   *   `destroy()` is network I/O, and the pod being shut down is often precisely the one that
+   *   cannot reach the broker - without a bound, one unreachable Redis holds the entire shutdown
+   *   open indefinitely.
    */
-  public async shutdown(_timeoutMs = 5000): Promise<void> {
+  public async shutdown(timeoutMs = 5000): Promise<void> {
     this.logger.info('Starting WebSocket graceful shutdown...');
 
     // Stop all heartbeats
@@ -58,7 +75,51 @@ export class HonoWebsocketAdapter extends AsenaWebsocketAdapter {
     // Clear connection tracking
     this.activeConnections.clear();
 
+    await this.destroyTransport(timeoutMs);
+
     this.logger.info('WebSocket shutdown complete');
+  }
+
+  /**
+   * Runs the transport's `destroy()` under a ceiling, containing every failure.
+   *
+   * A transport that throws or hangs must not abort the rest of the shutdown - the same policy
+   * the core applies to `@OnStop` hooks, and for the same reason: a shutdown that gives up
+   * halfway leaves more behind than one that limps to the end. The timer is cleared on the happy
+   * path too, so a fast teardown is not held up by a pending timeout.
+   *
+   * The transport reference is kept rather than cleared. Dropping it would silently downgrade a
+   * restarted server to `BunLocalTransport`, and every remote `destroy()` in the ecosystem is
+   * already idempotent.
+   *
+   * @param timeoutMs - Ceiling in milliseconds
+   */
+  private async destroyTransport(timeoutMs: number): Promise<void> {
+    const transport = this._transport;
+
+    if (typeof transport?.destroy !== 'function') {
+      return;
+    }
+
+    let timer: Timer | undefined;
+
+    try {
+      await Promise.race([
+        transport.destroy(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`WebSocket transport destroy() did not finish within ${timeoutMs}ms`)),
+            timeoutMs,
+          );
+        }),
+      ]);
+    } catch (error) {
+      this.logger.error('WebSocket transport teardown failed, continuing shutdown:', error);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
   }
 
   public registerWebSocket(webSocketService: AsenaWebSocketService<any>): void {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -13,19 +13,25 @@ import { flattenError, type ZodError } from 'zod';
  * application's `ConfigService.onError` like every other error instead of being
  * answered inside the validator middleware.
  *
- * Extends Hono's `HTTPException` with status 400 deliberately: an existing handler
- * that branches on `error instanceof HTTPException` and replies with `error.status`
- * keeps answering 400, so adopting this does not silently turn validation failures
- * into 500s.
+ * Extends Hono's `HTTPException` with status 400 deliberately: a handler that matches
+ * with `isHttpException()` - or with the older `error instanceof HTTPException` - and
+ * replies with `error.status` keeps answering 400, so adopting this does not silently
+ * turn validation failures into 500s.
+ *
+ * Note it does *not* extend `HttpException` from `@asenajs/asena/adapter`, the class
+ * applications throw. Both are branded, so `isHttpException()` cannot tell them apart and
+ * does not need to; `instanceof` can, which is one more reason not to reach for it.
  *
  * @example
  * ```typescript
  * public onError(error: Error, context: Context) {
+ *   // Before isHttpException: ValidationError is an HTTP exception too, so the
+ *   // generic branch below would otherwise swallow it.
  *   if (isValidationError(error)) {
  *     return context.send({ success: false, errors: error.issues }, 400);
  *   }
  *
- *   if (error instanceof HTTPException) {
+ *   if (isHttpException(error)) {
  *     return context.send({ error: error.message }, error.status);
  *   }
  *
@@ -99,9 +105,21 @@ export class ValidationError extends HTTPException implements ValidationErrorLik
  *
  * Without this the brand is a trap rather than a feature: the JSDoc on `isHttpException` tells
  * users to write `if (isHttpException(error)) ... else 500`, and on this adapter every
- * deliberate 401/403/404/429 would take the else branch and answer 500. `hono` is a *peer*
- * dependency, so two copies of it are more likely here than two copies of the adapter - which
- * is the situation the brand exists for in the first place.
+ * deliberate 401/403/404/429 raised by `hono/basic-auth`, `hono/jwt` or hono's own validator
+ * would take the else branch and answer 500.
+ *
+ * The brand covers one copy of `hono` and cannot reach another: it is installed on the prototype
+ * of the class *this* package resolved. Since 3.0.0 `hono` is a **peer** dependency, so this
+ * package has no resolution slot of its own and an application normally resolves exactly one copy
+ * - which is what makes the brand sufficient rather than a trap. Before that it was a regular
+ * dependency, and a downstream application that bumped its own `hono` range ended up with a second
+ * nested copy whose `HTTPException` was unbranded: every deliberate 400/403 answered 500 while the
+ * API kept responding. `warnOnNestedHono` below reports the one shape that can still produce it.
+ *
+ * Import `HTTPException` from `@asenajs/hono-adapter` rather than from `hono/http-exception` to
+ * stay on this package's copy regardless. The adapter's default response also checks
+ * `instanceof HTTPException` before the brand, so a hono exception is answered correctly even if
+ * this function never ran.
  *
  * Idempotent, and called from the HonoAdapter constructor.
  */
@@ -115,4 +133,54 @@ export const brandHonoHttpException = (): void => {
     enumerable: false,
     configurable: true,
   });
+};
+
+/**
+ * Warns when this package resolved a *nested* copy of `hono`.
+ *
+ * `hono` is a peer dependency, so it should always resolve from the application's own
+ * `node_modules`. A path under `@asenajs/hono-adapter/node_modules/hono` means a second copy was
+ * installed privately for this package - the exact topology that makes `brandHonoHttpException()`
+ * useless, because the brand lands on the prototype of *this* copy's class and an `HTTPException`
+ * the application threw from its own copy is neither `instanceof` it nor branded, so it is
+ * answered 500.
+ *
+ * This does not - and cannot - detect the *application's* copy. `import.meta.resolve` always
+ * answers relative to this module, Node resolution is per-importer so there is no single "the
+ * application's hono" to compare against, and after `asena build` or `bun build --compile` there
+ * is no `node_modules` to inspect at all. What it can prove is the asymmetric half: if *our* copy
+ * is nested, there are two. That is enough, because under a peer dependency a nested copy is the
+ * only way this package acquires one.
+ *
+ * Worth having even though the peer move makes the topology rare: `bun install` has been observed
+ * to drop the lockfile entry for a nested copy while leaving the directory on disk, so an
+ * application upgrading in place can still be broken by a leftover it cannot see.
+ *
+ * The path predicate is {@link isNestedHonoPath}, exported so it can be tested against both
+ * layouts directly - inside this repo `import.meta.resolve` always answers
+ * `hono-adapter/node_modules/hono`, which is the package's own root and deliberately does *not*
+ * match, so a test driving the real resolver could only ever assert the negative case.
+ */
+export const isNestedHonoPath = (resolved: string): boolean =>
+  resolved.includes('@asenajs/hono-adapter/node_modules/hono');
+
+export const warnOnNestedHono = (logger?: { warn: (message: string) => void }): void => {
+  try {
+    const resolved = import.meta.resolve('hono/http-exception');
+
+    if (!isNestedHonoPath(resolved)) {
+      return;
+    }
+
+    (logger ?? console).warn(
+      `A nested copy of \`hono\` was found at ${resolved}.\n` +
+        `  \`hono\` is a peer dependency of @asenajs/hono-adapter and must resolve from your\n` +
+        `  application's node_modules. With two copies, an HTTPException thrown from your copy is\n` +
+        `  not recognised by isHttpException() and will be answered as 500.\n` +
+        `  Fix: rm -rf node_modules bun.lock && bun install`,
+    );
+  } catch {
+    // `import.meta.resolve` is unavailable or throws under some bundlers and in compiled binaries.
+    // A diagnostic must never be the reason a server fails to boot.
+  }
 };

--- a/lib/middlewares/RateLimiterMiddleware.ts
+++ b/lib/middlewares/RateLimiterMiddleware.ts
@@ -48,6 +48,7 @@
  */
 
 import { type Context, MiddlewareService } from '../defaults';
+import { OnStop } from '@asenajs/asena/decorators/ioc';
 
 /**
  * Token bucket for a single client
@@ -396,14 +397,29 @@ export class RateLimiterMiddleware extends MiddlewareService {
   }
 
   /**
-   * Cleanup resources (stop cleanup timer)
+   * Cleanup resources (stop cleanup timer, drop bucket state)
    *
-   * Call this when shutting down the application.
+   * `@OnStop` hands this to the component lifecycle, so `server.stop()` calls it instead of the
+   * application having to remember to. The hook is inherited, so the `@Middleware()` subclass
+   * users actually register gets it without repeating the decorator - and it only fires for
+   * singletons, which is what a rate limiter has to be to share one bucket map across requests.
+   *
+   * The timer is `unref()`'d, so it never held the process open. What it does do is survive a
+   * stop/start cycle *inside* one process - twenty of them is an ordinary test suite - leaving a
+   * timer per stopped server still sweeping a bucket map nobody reads. The buckets go with it:
+   * a restarted server must not inherit the rate-limit state of the one before it, or the first
+   * requests after a restart get counted against a window that has already closed.
+   *
+   * Safe to call twice; the second call has nothing left to do.
    */
+  @OnStop()
   public destroy(): void {
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
     }
+
+    this.buckets.clear();
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "README.md",
     "LICENSE"
   ],
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "LibirSoft",
   "repository": {
     "type": "git",
@@ -41,23 +41,26 @@
     "release": "bun run build && changeset publish"
   },
   "devDependencies": {
-    "@asenajs/asena": "^0.9.0",
+    "@asenajs/asena": "^0.10.0",
     "@changesets/cli": "^2.30.0",
     "@types/bun": "latest",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^9.1.2",
+    "hono": "^4.12.32",
     "prettier": "^3.8.1",
-    "typescript-eslint": "^8.58.0"
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.58.0",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@asenajs/asena": "^0.9.0",
-    "typescript": "^5.8.2"
+    "@asenajs/asena": "^0.10.0",
+    "hono": ">=4.12.9",
+    "typescript": "^5.8.2",
+    "zod": "^4.3.6"
   },
   "dependencies": {
-    "@hono/zod-validator": "^0.9.0",
-    "hono": "^4.12.9",
-    "zod": "^4.3.6"
+    "@hono/zod-validator": "^0.9.0"
   }
 }

--- a/test/HonoTwoCopies.test.ts
+++ b/test/HonoTwoCopies.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { HTTPException } from 'hono/http-exception';
+import { HttpException, isHttpException } from '@asenajs/asena/adapter';
+import { HttpMethod } from '@asenajs/asena/web-types';
+import type { ServerLogger } from '@asenajs/asena/logger';
+import { HonoAdapter } from '../lib/HonoAdapter';
+import { isNestedHonoPath, warnOnNestedHono } from '../lib/errors';
+
+interface Entry {
+  level: string;
+  message: string;
+  meta?: any;
+}
+
+const capturingLogger = () => {
+  const entries: Entry[] = [];
+
+  const logger: ServerLogger & { debug: (message: string, meta?: any) => void } = {
+    info: (message, meta) => entries.push({ level: 'info', message, meta }),
+    warn: (message, meta) => entries.push({ level: 'warn', message, meta }),
+    error: (message, meta) => entries.push({ level: 'error', message, meta }),
+    profile: () => {},
+    debug: (message, meta) => entries.push({ level: 'debug', message, meta }),
+  };
+
+  return { logger, entries };
+};
+
+/**
+ * The incident, reduced to a unit test.
+ *
+ * A downstream application bumped `hono: ^4.12.9 -> ^4.12.32` in its own `package.json`. Bun kept
+ * the adapter's already-satisfied copy nested under `@asenajs/hono-adapter/node_modules/hono`, and
+ * every deliberate 400/403 thrown from `hono/http-exception` silently became a 500 while the API
+ * kept answering. Nothing crashed and no test failed.
+ *
+ * `brandHonoHttpException()` patches the prototype of the class *this package* resolved; a
+ * prototype patch cannot reach another copy's class. So a foreign `HTTPException` is neither
+ * `instanceof` the adapter's class nor branded, and `defaultErrorResponse` has nothing to
+ * recognise it by.
+ *
+ * **This test pins that behaviour rather than fixing it, because it cannot be fixed here.** The fix
+ * is packaging: since 3.0.0 `hono` is a peer dependency, so the adapter has no resolution slot of
+ * its own and the second copy cannot come into existence in the first place. What this file does is
+ * make the consequence explicit and permanent, so nobody re-introduces the dependency thinking the
+ * brand covers it.
+ *
+ * `hono/dist/http-exception.js` has zero imports - it is a bare `class HTTPException extends Error`
+ * - so copying the file to a second location produces a genuinely distinct class rather than a
+ * module that resolves back to the shared one. Same technique as `HttpExceptionTwoCopies.test.ts`.
+ */
+describe('a second resolved copy of hono', () => {
+  const copyDir = join(import.meta.dir, '.hono-two-copies-fixture');
+
+  let ForeignHTTPException: typeof HTTPException;
+  let server: { stop: (force?: boolean) => void; port: number } | undefined;
+
+  beforeAll(async () => {
+    rmSync(copyDir, { recursive: true, force: true });
+    mkdirSync(copyDir, { recursive: true });
+
+    const honoEntry = Bun.resolveSync('hono/http-exception', import.meta.dir);
+
+    cpSync(honoEntry, join(copyDir, 'http-exception.js'));
+
+    const foreign = await import(join(copyDir, 'http-exception.js'));
+
+    ForeignHTTPException = foreign.HTTPException;
+  });
+
+  afterAll(() => {
+    rmSync(copyDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    server?.stop(true);
+    server = undefined;
+  });
+
+  const bootThrowing = async (error: unknown) => {
+    const { logger, entries } = capturingLogger();
+    const adapter = new HonoAdapter({ logger });
+
+    adapter.setPort(0);
+    adapter.registerRoute({
+      method: HttpMethod.GET,
+      path: '/denied',
+      middlewares: [],
+      handler: () => {
+        throw error;
+      },
+      staticServe: null,
+      validator: null,
+    });
+
+    server = (await adapter.start()) as any;
+
+    const response = await fetch(`http://localhost:${server!.port}/denied`);
+
+    return { response, entries };
+  };
+
+  test('the copy really is a different class', () => {
+    // If this ever fails, the fixture collapsed back into one module and every assertion below
+    // silently stops testing anything.
+    expect(ForeignHTTPException).not.toBe(HTTPException);
+    expect(new ForeignHTTPException(403) instanceof HTTPException).toBe(false);
+  });
+
+  test('the brand does not cross copies - this is the whole problem', () => {
+    // eslint-disable-next-line no-new
+    new HonoAdapter({ logger: capturingLogger().logger });
+
+    expect(isHttpException(new HTTPException(403, { message: 'x' }))).toBe(true);
+    expect(isHttpException(new ForeignHTTPException(403, { message: 'x' }))).toBe(false);
+  });
+
+  // The documented failure, asserted as-is. A foreign hono exception carries no brand and is not
+  // an instance of the adapter's class, so there is nothing left to recognise it by and it takes
+  // the generic branch. Packaging is what stops an application ever reaching this state.
+  test('a foreign HTTPException is answered 500, not its own status', async () => {
+    const { response } = await bootThrowing(new ForeignHTTPException(403, { message: 'forbidden' }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Internal Server Error' });
+  });
+
+  test("the adapter's own copy is answered correctly, so the difference is the copy and nothing else", async () => {
+    const { response } = await bootThrowing(new HTTPException(403, { message: 'forbidden' }));
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('forbidden');
+  });
+
+  // The portable class brands each *instance*, so it does not depend on which copy of
+  // `@asenajs/asena` constructed it. This is why the docs tell applications to throw this one.
+  test('core HttpException is immune - it brands the instance, not a prototype', async () => {
+    const { response } = await bootThrowing(new HttpException(403, { error: 'forbidden' }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'forbidden' });
+  });
+});
+
+describe('warnOnNestedHono', () => {
+  // The predicate is tested directly rather than through the real resolver: inside this repo
+  // `import.meta.resolve` always answers `hono-adapter/node_modules/hono` - the package's own root,
+  // which correctly does not match - so driving the resolver could only ever assert the negative
+  // case and would pass just as happily against a function that returned early every time.
+  test('matches the installed layout where hono is nested under the adapter', () => {
+    expect(
+      isNestedHonoPath('file:///app/node_modules/@asenajs/hono-adapter/node_modules/hono/dist/http-exception.js'),
+    ).toBe(true);
+  });
+
+  test('does not match hono resolved from the application, which is what a peer produces', () => {
+    expect(isNestedHonoPath('file:///app/node_modules/hono/dist/http-exception.js')).toBe(false);
+  });
+
+  test('does not match this repo, where hono is a devDependency at the package root', () => {
+    expect(isNestedHonoPath(import.meta.resolve('hono/http-exception'))).toBe(false);
+  });
+
+  test('says nothing here, and never throws whatever the resolution environment', () => {
+    const messages: string[] = [];
+
+    warnOnNestedHono({ warn: (message) => messages.push(message) });
+
+    expect(messages).toHaveLength(0);
+    expect(() => warnOnNestedHono()).not.toThrow();
+  });
+});

--- a/test/HttpExceptionBrand.test.ts
+++ b/test/HttpExceptionBrand.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { HTTPException } from 'hono/http-exception';
-import { isHttpException, HTTP_EXCEPTION } from '@asenajs/asena/adapter';
+import { isHttpException, HTTP_EXCEPTION, HttpException } from '@asenajs/asena/adapter';
 import { HonoAdapter } from '../lib/HonoAdapter';
 import { ValidationError } from '../lib/errors';
 import type { ServerLogger } from '@asenajs/asena/logger';
@@ -13,12 +13,14 @@ const mockLogger: ServerLogger = {
 };
 
 /**
- * Byte-for-byte the same contract as `ergenecore/test/HttpExceptionBrand.test.ts`.
+ * The same contract as `ergenecore/test/HttpExceptionBrand.test.ts`, plus the cases that only
+ * exist here.
  *
- * The class users throw on this adapter is Hono's own `HTTPException`, which this package does
- * not own and therefore cannot declare the brand on. `brandHonoHttpException()` puts it on the
- * prototype from the adapter constructor. `hono` is a *peer* dependency, so two copies of it are
- * more likely here than two copies of the adapter - exactly the case the brand exists for.
+ * Applications throw `HttpException` from `@asenajs/asena/adapter`. Hono's ecosystem throws
+ * `HTTPException`, a class this package does not own and therefore cannot declare the brand on -
+ * `brandHonoHttpException()` puts it on the prototype from the adapter constructor. `hono` is a
+ * regular dependency here, but applications routinely depend on it directly as well, so a second
+ * resolved copy is ordinary rather than exotic - exactly the case the brand exists for.
  */
 describe('HttpException brand (hono)', () => {
   test("Hono's own HTTPException is branded once the adapter is constructed", () => {
@@ -46,8 +48,8 @@ describe('HttpException brand (hono)', () => {
     expect(isHttpException(new ValidationError({ issues: [] } as any, 'json'))).toBe(true);
   });
 
-  // The case the brand exists for: `hono` is a peer dependency, so a second resolved copy is
-  // plausible and `error instanceof HTTPException` answers false for it. The predicate must
+  // The case the brand exists for: an application depending on `hono` directly can resolve a
+  // second copy, and `error instanceof HTTPException` answers false for it. The predicate must
   // still recognise it, or the documented `if (isHttpException(error)) … else 500` pattern
   // turns every deliberate 401/403/404 into a generic 500.
   test('recognises an HTTPException from a second copy of hono', () => {
@@ -79,5 +81,43 @@ describe('HttpException brand (hono)', () => {
     expect(isHttpException(new Error('nope'))).toBe(false);
     expect(isHttpException(null)).toBe(false);
     expect(isHttpException({ [HTTP_EXCEPTION]: false })).toBe(false);
+  });
+
+  // Two throwable, branded classes now reach an application running on this adapter: the portable
+  // one from `@asenajs/asena/adapter`, and hono's own, which its ecosystem middlewares throw.
+  // `isHttpException` covers both and is the reason an application does not have to care which it
+  // is holding. `instanceof` does care, and these are the assertions that say so out loud.
+  describe("the core class and hono's are both branded, and are not each other", () => {
+    test('the core class is branded', () => {
+      // eslint-disable-next-line no-new
+      new HonoAdapter(mockLogger);
+
+      expect(isHttpException(new HttpException(401, 'Unauthorized'))).toBe(true);
+    });
+
+    test("the core class is not hono's HTTPException", () => {
+      expect(new HttpException(401, 'Unauthorized') instanceof HTTPException).toBe(false);
+    });
+
+    test("ValidationError extends hono's, not the core class", () => {
+      // Deliberate: an existing handler branching on `instanceof HTTPException` keeps answering
+      // 400 for a validation failure. It is also why `instanceof` is the wrong tool here - the
+      // two branded classes sort differently under it and identically under the guard.
+      const error = new ValidationError({ issues: [] } as any, 'json');
+
+      expect(error instanceof HTTPException).toBe(true);
+      expect(error instanceof HttpException).toBe(false);
+      expect(isHttpException(error)).toBe(true);
+    });
+
+    test('this package does not export the core class under a confusable name', async () => {
+      const exports = await import('../index');
+
+      // `HttpException` and `HTTPException` differ by the case of two letters. Only hono's is
+      // exported from here; the portable one comes from `@asenajs/asena/adapter`, so autocomplete
+      // in a hono project cannot silently offer the wrong one.
+      expect('HTTPException' in exports).toBe(true);
+      expect('HttpException' in exports).toBe(false);
+    });
   });
 });

--- a/test/HttpExceptionTwoCopies.test.ts
+++ b/test/HttpExceptionTwoCopies.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { HTTP_EXCEPTION, HttpException } from '@asenajs/asena/adapter';
+import { HttpMethod } from '@asenajs/asena/web-types';
+import type { ServerLogger } from '@asenajs/asena/logger';
+import { HonoAdapter } from '../lib/HonoAdapter';
+
+interface Entry {
+  level: string;
+  message: string;
+  meta?: any;
+}
+
+const capturingLogger = () => {
+  const entries: Entry[] = [];
+
+  const logger: ServerLogger & { debug: (message: string, meta?: any) => void } = {
+    info: (message, meta) => entries.push({ level: 'info', message, meta }),
+    warn: (message, meta) => entries.push({ level: 'warn', message, meta }),
+    error: (message, meta) => entries.push({ level: 'error', message, meta }),
+    profile: () => {},
+    debug: (message, meta) => entries.push({ level: 'debug', message, meta }),
+  };
+
+  return { logger, entries };
+};
+
+/**
+ * The twin of `ergenecore/test/HttpExceptionTwoCopies.test.ts`, and new to this adapter.
+ *
+ * `HttpException` now lives in `@asenajs/asena/adapter`, which is a **peer** dependency of this
+ * package - so an application resolving two copies of it produces two distinct `HttpException`
+ * classes, and `instanceof` answers false for one of them. That is the topology the
+ * `Symbol.for('asena.httpException')` brand exists for.
+ *
+ * This adapter never had a foreign-copy branch at all: its default response was chosen purely by
+ * `error instanceof HTTPException`, so a foreign exception answered a generic 500 while the log
+ * line - computed separately, by duck-typing `.status` - claimed the status it carried. The
+ * response and the record disagreed about the same request, which is worse than either being
+ * wrong on its own.
+ *
+ * A hand-built object cannot prove the fix: it is not an instance of anything, so `instanceof`
+ * was always going to answer false for it. This copies the built core module - which has no
+ * imports at all after `import type` erasure, and declares the registered symbol in-file - so the
+ * copy is a genuinely distinct class carrying an identical brand.
+ */
+describe('HttpException from a second resolved copy of @asenajs/asena', () => {
+  const copyDir = join(import.meta.dir, '.two-copies-fixture');
+
+  let ForeignHttpException: typeof HttpException;
+  let server: { stop: (force?: boolean) => void; port: number } | undefined;
+
+  beforeAll(async () => {
+    rmSync(copyDir, { recursive: true, force: true });
+    mkdirSync(copyDir, { recursive: true });
+
+    const coreAdapterEntry = Bun.resolveSync('@asenajs/asena/adapter', import.meta.dir);
+
+    cpSync(join(dirname(coreAdapterEntry), 'types', 'HttpException.js'), join(copyDir, 'HttpException.js'));
+
+    const foreign = await import(join(copyDir, 'HttpException.js'));
+
+    ForeignHttpException = foreign.HttpException;
+
+    // If the core module ever grows a runtime import, the copy resolves it back to the shared
+    // module and stops being a second copy in the way that matters.
+    expect(foreign.HTTP_EXCEPTION).toBe(HTTP_EXCEPTION);
+  });
+
+  afterAll(() => {
+    rmSync(copyDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    server?.stop(true);
+    server = undefined;
+  });
+
+  const bootThrowing = async (error: unknown) => {
+    const { logger, entries } = capturingLogger();
+    const adapter = new HonoAdapter({ logger });
+
+    adapter.setPort(0);
+    adapter.registerRoute({
+      method: HttpMethod.GET,
+      path: '/denied',
+      middlewares: [],
+      handler: () => {
+        throw error;
+      },
+      staticServe: null,
+      validator: null,
+    });
+
+    server = (await adapter.start()) as any;
+
+    const response = await fetch(`http://localhost:${server!.port}/denied`);
+
+    return { response, entries };
+  };
+
+  test('the copy really is a different class', () => {
+    const foreign = new ForeignHttpException(401, 'Unauthorized');
+
+    // If this ever passes, the copy collapsed back into one module and every assertion below
+    // silently stops testing anything.
+    expect(foreign instanceof HttpException).toBe(false);
+    expect(foreign.status).toBe(401);
+  });
+
+  test('a foreign 401 is answered 401, not 500', async () => {
+    const { response } = await bootThrowing(new ForeignHttpException(401, { error: 'Unauthorized' }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  test('a foreign 401 is logged as a rejected request, not an application error', async () => {
+    const { entries } = await bootThrowing(new ForeignHttpException(401, 'Unauthorized'));
+
+    expect(entries.some((entry) => entry.level === 'error')).toBe(false);
+
+    const entry = entries.find((e) => e.message === 'Request rejected:');
+
+    expect(entry?.level).toBe('debug');
+    expect(entry?.meta.status).toBe(401);
+    // A stack on a 4xx is the payload of the flood, not just the wrong label.
+    expect(entry?.meta.stack).toBeUndefined();
+  });
+
+  test('a foreign 5xx is still an application error with a stack', async () => {
+    const { response, entries } = await bootThrowing(new ForeignHttpException(503, 'Upstream down'));
+
+    expect(response.status).toBe(503);
+
+    const entry = entries.find((e) => e.message === 'Application error occurred:');
+
+    expect(entry?.level).toBe('error');
+    expect(entry?.meta.status).toBe(503);
+    expect(typeof entry?.meta.stack).toBe('string');
+  });
+
+  test('a foreign subclass is treated the same as a foreign base', async () => {
+    class ForeignForbidden extends ForeignHttpException {
+      public constructor() {
+        super(403, { error: 'Forbidden' });
+      }
+    }
+
+    const { response, entries } = await bootThrowing(new ForeignForbidden());
+
+    expect(response.status).toBe(403);
+    expect(entries.some((entry) => entry.level === 'error')).toBe(false);
+    expect(entries.find((e) => e.message === 'Request rejected:')?.meta.status).toBe(403);
+  });
+
+  test('the local copy behaves identically, so the two cannot drift', async () => {
+    const { response, entries } = await bootThrowing(new HttpException(401, { error: 'Unauthorized' }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    expect(entries.find((e) => e.message === 'Request rejected:')?.meta.status).toBe(401);
+  });
+});

--- a/test/Shutdown.test.ts
+++ b/test/Shutdown.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import type { Server } from 'bun';
+import { AsenaWebSocketService, type WebSocketTransport } from '@asenajs/asena/web-socket';
+import { Container } from '@asenajs/asena/container';
+import { HonoWebsocketAdapter } from '../lib/HonoWebsocketAdapter';
+import { RateLimiterMiddleware } from '../lib/middlewares/RateLimiterMiddleware';
+import { createMockLogger, createTestAdapter, registerRoute, sleep, startTestServer } from './utils/testHelpers';
+
+/**
+ * Minimal WebSocket service - the adapter only starts a transport when at least one namespace
+ * is registered, so every transport test needs one.
+ */
+class TestWebSocketService extends AsenaWebSocketService<any> {
+  protected async onMessage(ws: any, message: Buffer | string) {
+    ws.send(typeof message === 'string' ? message : message.toString());
+  }
+}
+
+function createTestWsService(namespace: string): TestWebSocketService {
+  const service = new TestWebSocketService();
+
+  service.namespace = namespace;
+
+  return service;
+}
+
+/**
+ * A stand-in for a remote transport (RedisTransport and friends): the only thing under test is
+ * whether `destroy()` is reached, so the publish path is a no-op.
+ */
+function createRecordingTransport(destroyImpl?: () => Promise<void>) {
+  const destroy = mock(destroyImpl ?? (async () => {}));
+
+  const transport: WebSocketTransport = {
+    publish: () => {},
+    init: async () => {},
+    destroy,
+  };
+
+  return { transport, destroy };
+}
+
+describe('Shutdown', () => {
+  let server: Server<any> | undefined;
+
+  afterEach(() => {
+    if (server) {
+      server.stop(true);
+      server = undefined;
+    }
+  });
+
+  // ─── Transport teardown ───────────────────────────────────────────
+
+  describe('WebSocket transport', () => {
+    it('should reach transport.destroy() through adapter.stop()', async () => {
+      const { adapter, wsAdapter } = createTestAdapter();
+      const { transport, destroy } = createRecordingTransport();
+
+      wsAdapter.transport = transport;
+
+      adapter.registerWebsocketRoute({
+        path: 'chat',
+        middlewares: [],
+        websocketService: createTestWsService('chat') as any,
+      });
+
+      await registerRoute(adapter, { path: '/health' });
+
+      const { server: s, port } = await startTestServer(adapter);
+
+      server = s;
+
+      expect(destroy).not.toHaveBeenCalled();
+
+      await adapter.stop();
+      server = undefined;
+
+      expect(destroy).toHaveBeenCalledTimes(1);
+      // ...and the socket really is down, not merely reported as such
+      await expect(fetch(`http://localhost:${port}/health`)).rejects.toThrow();
+    });
+
+    it('should reach transport.destroy() through wsAdapter.shutdown()', async () => {
+      const logger = createMockLogger();
+      const wsAdapter = new HonoWebsocketAdapter(logger);
+      const { transport, destroy } = createRecordingTransport();
+
+      wsAdapter.transport = transport;
+
+      await wsAdapter.shutdown();
+
+      expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should survive a transport whose destroy() rejects', async () => {
+      const logger = createMockLogger();
+      const wsAdapter = new HonoWebsocketAdapter(logger);
+      const { transport } = createRecordingTransport(async () => {
+        throw new Error('broker unreachable');
+      });
+
+      wsAdapter.transport = transport;
+
+      await wsAdapter.shutdown();
+
+      expect(logger.error).toHaveBeenCalled();
+      // The rest of the teardown still ran
+      expect(logger.info).toHaveBeenCalledWith('WebSocket shutdown complete');
+    });
+
+    it('should bound a transport whose destroy() never settles', async () => {
+      const logger = createMockLogger();
+      const wsAdapter = new HonoWebsocketAdapter(logger);
+      const { transport } = createRecordingTransport(() => new Promise<void>(() => {}));
+
+      wsAdapter.transport = transport;
+
+      const started = Date.now();
+
+      await wsAdapter.shutdown(50);
+
+      // The whole point of the timeout: an unreachable broker must not hold the shutdown open
+      expect(Date.now() - started).toBeLessThan(2000);
+      expect(logger.error).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith('WebSocket shutdown complete');
+    });
+
+    it('should not fail when no transport was configured', async () => {
+      const logger = createMockLogger();
+      const wsAdapter = new HonoWebsocketAdapter(logger);
+
+      await wsAdapter.shutdown();
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Heartbeats ───────────────────────────────────────────────────
+
+  describe('Heartbeats', () => {
+    it('should clear heartbeat intervals of still-open connections', async () => {
+      const { adapter, wsAdapter } = createTestAdapter();
+
+      adapter.registerWebsocketRoute({
+        path: 'beat',
+        middlewares: [],
+        websocketService: createTestWsService('beat') as any,
+      });
+
+      await registerRoute(adapter, { path: '/health' });
+
+      await adapter.serveOptions(() => ({
+        wsOptions: { sendPingStrategy: 'adapter', heartbeatInterval: 50, idleTimeout: 0 },
+      }));
+
+      const { server: s } = await startTestServer(adapter);
+
+      server = s;
+
+      const ws = new WebSocket(`ws://localhost:${server.port}/beat`);
+
+      await new Promise<void>((resolve) => {
+        ws.onopen = () => resolve();
+      });
+
+      await sleep(50);
+
+      // Read through the protected field: a live timer has no public surface, and the point of
+      // the test is that nothing is left behind rather than that some getter says so.
+      const heartbeats = wsAdapter['heartbeatIntervals'] as Map<string, Timer>;
+
+      expect(heartbeats.size).toBe(1);
+
+      // Directly, with the connection still open - stopping the server first would empty the map
+      // via the close handler and prove nothing about shutdown().
+      await wsAdapter.shutdown();
+
+      expect(heartbeats.size).toBe(0);
+      expect(wsAdapter.getConnectionCount('beat')).toBe(0);
+
+      ws.close();
+      await sleep(50);
+    });
+  });
+
+  // ─── Failure containment ──────────────────────────────────────────
+
+  describe('Failure containment', () => {
+    it('should stop the HTTP server even when the WebSocket shutdown throws', async () => {
+      const { adapter, wsAdapter, logger } = createTestAdapter();
+
+      await registerRoute(adapter, { path: '/health' });
+
+      const { server: s, port } = await startTestServer(adapter);
+
+      server = s;
+
+      wsAdapter.shutdown = mock(async () => {
+        throw new Error('shutdown exploded');
+      });
+
+      await adapter.stop();
+      server = undefined;
+
+      expect(logger.error).toHaveBeenCalled();
+      await expect(fetch(`http://localhost:${port}/health`)).rejects.toThrow();
+    });
+
+    it('should release the transport even when server.stop() fails', async () => {
+      const { adapter, wsAdapter } = createTestAdapter();
+      const { transport, destroy } = createRecordingTransport();
+
+      wsAdapter.transport = transport;
+
+      // A Bun server that refuses to stop cannot be produced on demand, so stand one in. The
+      // branch being covered is the `finally`, not Bun's behaviour.
+      adapter['server'] = {
+        stop: () => {
+          throw new Error('stop failed');
+        },
+      } as any;
+
+      await expect(adapter.stop()).rejects.toThrow('stop failed');
+
+      expect(destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be safe to stop twice', async () => {
+      const { adapter, wsAdapter } = createTestAdapter();
+      const { transport, destroy } = createRecordingTransport();
+
+      wsAdapter.transport = transport;
+
+      await registerRoute(adapter, { path: '/health' });
+
+      const { server: s } = await startTestServer(adapter);
+
+      server = s;
+
+      await adapter.stop();
+      await adapter.stop();
+      server = undefined;
+
+      expect(destroy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── Component lifecycle ──────────────────────────────────────────
+
+  describe('RateLimiterMiddleware lifecycle', () => {
+    it('should expose destroy() as an @OnStop hook', () => {
+      // The container's own walk, so the test cannot disagree with what the framework would run
+      const stopHooks = new Container().getStopHooks(RateLimiterMiddleware as any);
+
+      expect(stopHooks).toContain('destroy');
+    });
+
+    it('should inherit the hook in the subclass users actually register', () => {
+      class ApiRateLimiter extends RateLimiterMiddleware {}
+
+      const stopHooks = new Container().getStopHooks(ApiRateLimiter as any);
+
+      expect(stopHooks).toEqual(['destroy']);
+    });
+
+    it('should drop timer and buckets so a restart starts clean', () => {
+      const limiter = new RateLimiterMiddleware({ capacity: 5, refillRate: 1, cleanupInterval: 1000 });
+
+      limiter['buckets'].set('1.2.3.4', { tokens: 0, lastRefill: Date.now() });
+
+      expect(limiter.getBucketState('1.2.3.4')).toBeDefined();
+      expect(limiter['cleanupTimer']).toBeDefined();
+
+      limiter.destroy();
+
+      expect(limiter.getBucketState('1.2.3.4')).toBeUndefined();
+      expect(limiter['cleanupTimer']).toBeUndefined();
+
+      // Second call has nothing left to do, and must not throw
+      limiter.destroy();
+    });
+  });
+});

--- a/test/coreHttpException.test.ts
+++ b/test/coreHttpException.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { HTTP_EXCEPTION, HttpException, isHttpException } from '@asenajs/asena/adapter';
+import { HttpMethod } from '@asenajs/asena/web-types';
+import type { ServerLogger } from '@asenajs/asena/logger';
+import { HTTPException } from 'hono/http-exception';
+import { basicAuth } from 'hono/basic-auth';
+import { bearerAuth } from 'hono/bearer-auth';
+import { z } from 'zod';
+import { HonoAdapter } from '../lib/HonoAdapter';
+
+/**
+ * `HttpException` is declared in `@asenajs/asena/adapter` and is the class applications throw on
+ * *both* adapters - the same class object, so one `throw` behaves identically whichever adapter
+ * the application runs on. This adapter deliberately does not re-export it.
+ *
+ * This adapter is the one where that could go wrong. Its default response used to be chosen by
+ * `error instanceof HTTPException`, which is false for the core class, so a `throw new
+ * HttpException(401, ...)` would have answered a generic 500 while the log line - chosen by a
+ * separate duck-type on `.status` - claimed 401. Two mechanisms, two answers, for one request.
+ *
+ * The other half of this file is the regression guard that matters more: hono's own
+ * `HTTPException` must keep working exactly as before, because `hono/basic-auth`,
+ * `hono/bearer-auth`, `hono/jwt` and hono's own validator all throw it and applications depend on
+ * those packages.
+ */
+interface Entry {
+  level: string;
+  message: string;
+  meta?: any;
+}
+
+const capturingLogger = () => {
+  const entries: Entry[] = [];
+
+  const logger: ServerLogger & { debug: (message: string, meta?: any) => void } = {
+    info: (message, meta) => entries.push({ level: 'info', message, meta }),
+    warn: (message, meta) => entries.push({ level: 'warn', message, meta }),
+    error: (message, meta) => entries.push({ level: 'error', message, meta }),
+    profile: () => {},
+    debug: (message, meta) => entries.push({ level: 'debug', message, meta }),
+  };
+
+  return { logger, entries };
+};
+
+describe('core HttpException on the hono adapter', () => {
+  let server: { stop: (force?: boolean) => void; port: number } | undefined;
+
+  afterEach(() => {
+    server?.stop(true);
+    server = undefined;
+  });
+
+  /** Boots an adapter whose single route throws `error`, with the requested `onError` behaviour. */
+  const bootThrowing = async (error: unknown, onError: 'none' | 'answers' | 'declines' = 'none') => {
+    const { logger, entries } = capturingLogger();
+    const adapter = new HonoAdapter({ logger });
+
+    adapter.setPort(0);
+    adapter.registerRoute({
+      method: HttpMethod.GET,
+      path: '/denied',
+      middlewares: [],
+      handler: () => {
+        throw error;
+      },
+      staticServe: null,
+      validator: null,
+    });
+
+    if (onError === 'answers') {
+      adapter.onError((thrown, context) =>
+        isHttpException(thrown) ? context.send({ mine: true }, thrown.status) : context.send({ mine: false }, 500),
+      );
+    } else if (onError === 'declines') {
+      adapter.onError((() => undefined) as any);
+    }
+
+    server = (await adapter.start()) as any;
+
+    const response = await fetch(`http://localhost:${server!.port}/denied`);
+
+    return { response, entries };
+  };
+
+  describe('the adapter answers it from its own status and body', () => {
+    it('with no onError declared', async () => {
+      const { response } = await bootThrowing(
+        new HttpException(401, { error: 'nope' }, { headers: { 'WWW-Authenticate': 'Bearer' } }),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({ error: 'nope' });
+      expect(response.headers.get('content-type')).toContain('application/json');
+      // Proves `getResponse()` produced this rather than a status-only fallback: a fallback has
+      // no way to know about a custom header.
+      expect(response.headers.get('WWW-Authenticate')).toBe('Bearer');
+    });
+
+    it('when onError declines by returning nothing', async () => {
+      const { response, entries } = await bootThrowing(new HttpException(401, { error: 'nope' }), 'declines');
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({ error: 'nope' });
+
+      // The framework answered, so the framework records it - at a level matching the status.
+      const entry = entries.find((e) => e.message === 'Request rejected:');
+
+      expect(entry?.level).toBe('debug');
+      expect(entry?.meta.status).toBe(401);
+      expect(entry?.meta.stack).toBeUndefined();
+    });
+
+    it('yields to onError when it answers, and writes no line of its own', async () => {
+      const { response, entries } = await bootThrowing(new HttpException(403, 'Forbidden'), 'answers');
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ mine: true });
+
+      // The application answered, so it owns the record - a second line from the adapter would
+      // only duplicate it, without whatever correlation id the application carries.
+      expect(entries.some((e) => e.message === 'Request rejected:')).toBe(false);
+      expect(entries.some((e) => e.message === 'Application error occurred:')).toBe(false);
+    });
+
+    it('treats a 5xx as an application error, with a stack', async () => {
+      const { response, entries } = await bootThrowing(new HttpException(503, 'Upstream down'));
+
+      expect(response.status).toBe(503);
+      expect(await response.text()).toBe('Upstream down');
+
+      const entry = entries.find((e) => e.message === 'Application error occurred:');
+
+      expect(entry?.level).toBe('error');
+      expect(entry?.meta.status).toBe(503);
+      expect(typeof entry?.meta.stack).toBe('string');
+    });
+
+    it("is branded, and is not hono's HTTPException", async () => {
+      const error = new HttpException(401, 'Unauthorized');
+
+      expect(isHttpException(error)).toBe(true);
+      // The reason the adapter cannot dispatch on `instanceof HTTPException` alone.
+      expect(error instanceof HTTPException).toBe(false);
+    });
+  });
+
+  // Everything below is a regression guard. None of it is new behaviour; all of it would break
+  // silently if the default response stopped recognising hono's own exception class.
+  describe("hono's own HTTPException keeps working", () => {
+    it('is answered from its own status and message', async () => {
+      const { response } = await bootThrowing(new HTTPException(403, { message: 'Insufficient scope' }));
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toBe('Insufficient scope');
+    });
+
+    it('keeps the headers of a pre-built res', async () => {
+      const res = new Response(JSON.stringify({ error: 'nope' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer realm="api"' },
+      });
+
+      const { response } = await bootThrowing(new HTTPException(401, { res }));
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({ error: 'nope' });
+      expect(response.headers.get('WWW-Authenticate')).toBe('Bearer realm="api"');
+    });
+
+    // Hono throws this from inside the adapter's own validation chain, not from user code, so it
+    // is on the hot path of every validated POST rather than an exotic case.
+    it("survives hono's validator rejecting a malformed JSON body", async () => {
+      const { logger } = capturingLogger();
+      const adapter = new HonoAdapter({ logger });
+
+      adapter.setPort(0);
+      adapter.registerRoute({
+        method: HttpMethod.POST,
+        path: '/users',
+        middlewares: [],
+        handler: (context: any) => context.send({ ok: true }),
+        staticServe: null,
+        validator: { json: { handle: () => z.object({ name: z.string() }), override: false } } as any,
+      });
+
+      server = (await adapter.start()) as any;
+
+      const response = await fetch(`http://localhost:${server!.port}/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{',
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('Malformed JSON in request body');
+    });
+  });
+
+  // The path a real application takes to use a hono package: an `override` middleware receives the
+  // raw hono context, so a hono middleware can be handed through untouched.
+  describe('hono ecosystem middlewares, end to end', () => {
+    const bootWithMiddleware = async (handle: unknown) => {
+      const { logger, entries } = capturingLogger();
+      const adapter = new HonoAdapter({ logger });
+
+      adapter.setPort(0);
+      adapter.registerRoute({
+        method: HttpMethod.GET,
+        path: '/vault',
+        middlewares: [{ handle, override: true } as any],
+        handler: (context: any) => context.send({ ok: true }),
+        staticServe: null,
+        validator: null,
+      });
+
+      server = (await adapter.start()) as any;
+
+      return { entries, url: `http://localhost:${server!.port}/vault` };
+    };
+
+    it('bearerAuth still answers 401 with its WWW-Authenticate header', async () => {
+      const { entries, url } = await bootWithMiddleware(bearerAuth({ token: 's3cr3t' }));
+
+      const response = await fetch(url);
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).toContain('Bearer');
+
+      // And the rejection is logged as a rejection, not as an application error with a stack -
+      // a bot spraying a public endpoint must not be able to fill the error stream.
+      const entry = entries.find((e) => e.message === 'Request rejected:');
+
+      expect(entry?.level).toBe('debug');
+      expect(entry?.meta.status).toBe(401);
+    });
+
+    it('bearerAuth still lets a correct token through', async () => {
+      const { url } = await bootWithMiddleware(bearerAuth({ token: 's3cr3t' }));
+
+      const response = await fetch(url, { headers: { Authorization: 'Bearer s3cr3t' } });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+    });
+
+    it('basicAuth still answers 401', async () => {
+      const { url } = await bootWithMiddleware(basicAuth({ username: 'admin', password: 'hunter2' }));
+
+      const response = await fetch(url);
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).toContain('Basic');
+    });
+
+    it('basicAuth still lets correct credentials through', async () => {
+      const { url } = await bootWithMiddleware(basicAuth({ username: 'admin', password: 'hunter2' }));
+
+      const response = await fetch(url, {
+        headers: { Authorization: `Basic ${btoa('admin:hunter2')}` },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+    });
+  });
+
+  describe('a branded exception this adapter does not own', () => {
+    /** What a second resolved copy, or a foreign implementation of the contract, looks like. */
+    const brandedOnly = (status: number, message = 'from somewhere else') =>
+      Object.assign(Object.create(Error.prototype), { [HTTP_EXCEPTION]: true, status, message }) as unknown;
+
+    it('answers its own status instead of collapsing to 500', async () => {
+      const { response } = await bootThrowing(brandedOnly(429, 'slow down'));
+
+      expect(response.status).toBe(429);
+    });
+
+    it('withholds its message - only status is in the contract', async () => {
+      const { response } = await bootThrowing(brandedOnly(429, 'slow down'));
+
+      expect(await response.json()).toEqual({ error: 'Internal Server Error' });
+    });
+
+    it('is logged at the level its status implies', async () => {
+      const { entries } = await bootThrowing(brandedOnly(403));
+
+      expect(entries.some((entry) => entry.level === 'error')).toBe(false);
+      expect(entries.find((e) => e.message === 'Request rejected:')?.meta.status).toBe(403);
+    });
+  });
+
+  // The invariant, stated once so the two mechanisms can never drift apart again. Both used to be
+  // computed independently: the response by `instanceof`, the log by duck-typing `.status`.
+  describe('the logged status always equals the answered status', () => {
+    const cases: [string, unknown][] = [
+      ['core HttpException 401', new HttpException(401, 'Unauthorized')],
+      ['core HttpException 503', new HttpException(503, 'Upstream down')],
+      ['hono HTTPException 401', new HTTPException(401, { message: 'Unauthorized' })],
+      [
+        'branded without getResponse',
+        Object.assign(Object.create(Error.prototype), { [HTTP_EXCEPTION]: true, status: 401, message: 'x' }),
+      ],
+      ['plain Error', new Error('kaboom')],
+      // The case the old duck-type got wrong on its own terms: answered 500, logged as a 4xx.
+      ['plain Error with a stray .status', Object.assign(new Error('kaboom'), { status: 401 })],
+    ];
+
+    for (const [name, error] of cases) {
+      it(name, async () => {
+        const { response, entries } = await bootThrowing(error);
+
+        const entry = entries.find(
+          (e) => e.message === 'Request rejected:' || e.message === 'Application error occurred:',
+        );
+
+        expect(entry?.meta.status).toBe(response.status);
+      });
+    }
+  });
+});


### PR DESCRIPTION
  The adapter's job is to offer a wrapper, not to supply the framework it wraps. Both libraries are
  part of the contract between this package and your application - `HTTPException` and `Context` come
  from hono, `ValidationService.json()` returns a zod schema, and all of them appear in the published
  `.d.ts` - so both must be the _same copy_ your application resolves. Declaring them as
  `dependencies` gave this package its own resolution slot, and that slot is a bug waiting for a
  lockfile to fill it.

  It did. A downstream application bumped `hono: ^4.12.9 -> ^4.12.32`, bun kept the adapter's
  already-satisfied copy nested under `@asenajs/hono-adapter/node_modules/hono`, and every deliberate
  400/403 thrown from `hono/http-exception` silently became a 500 while the API kept answering. 46/46
  of that app's tests stayed green. `brandHonoHttpException()` patches the prototype of the copy _this
  package_ resolved; a prototype patch cannot reach another copy's class. The split was not even
  semver-forced - `4.12.32` satisfied `^4.12.9` too. Only the extra resolution slot made it possible.